### PR TITLE
make platform review dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,8 @@ updates:
       interval: weekly
       day: "monday"
       time: "06:00"
+    reviewers:
+      - "thermondo/platform"
     open-pull-requests-limit: 20
     allow:
       - dependency-type: direct


### PR DESCRIPTION
dependabot hasn't been running because github noticed we never touch the dependabot PRs.

should probably change that.